### PR TITLE
fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,18 +17,3 @@ updates:
         update-types:
           - "patch"
           - "minor"
-
-  # Cargo security update
-  - package-ecosystem: cargo
-    directory: /
-    schedule:
-      # Very frequent checks for security updates
-      interval: daily
-    # Never let spam converns prevent security updates
-    open-pull-requests-limit: 0
-    ignore:
-      # Ignore all version updates
-      update-types:
-        - "version-update:patch"
-        - "version-update:minor"
-        - "version-update:major"


### PR DESCRIPTION
Okay, so apparently Dependabot had changed since I last used it, which I did not notice as I don't have full access to the repo. Some Dependabot settings can now be configured in the admin panel.

@lut99: Could you enable the following settings in `Settings > Code Security`?

Under Dependabot:

- Dependabot alerts
- Dependabot security updates
- Dependabot version updates
- Dependabot on Actions runners

It looks like that last setting is why the Dependabot file was inert.

Since the Dependabot settings in the interface can take care of security updates now, we can remove that part from the configuration as it would be redundant. This PR removes that section.

These can now be separately handled in the GitHub settings, after which
they are coupled with the Dependabot alerts.
